### PR TITLE
Move to kilo-io organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import (
 	"log"
 
 	ipt "github.com/coreos/go-iptables/iptables"
-	iptp "github.com/leonnicolas/iptables_parser"
+	iptp "github.com/kilo-io/iptables_parser"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/leonnicolas/iptables_parser
+module github.com/kilo-io/iptables_parser
 
 go 1.16

--- a/parser.go
+++ b/parser.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	vd "github.com/leonnicolas/iptables_parser/validate_dns"
+	vd "github.com/kilo-io/iptables_parser/validate_dns"
 )
 
 // Line represents a line in a iptables dump, e.g. generated with iptables-save.


### PR DESCRIPTION
This commit changes the module name from
github.com/leonnicolas/iptables_parser to
github.com/kilo-io/iptables_parser.

Signed-off-by: leonnicolas <leonloechner@gmx.de>