### PR TITLE
parser.go: ipv6 address without network mask support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.16'
+          go-version: '1.18'
       - run: go test ./...
   fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.16'
+          go-version: '1.18'
       - run: '[ -z "$(gofmt -e -d ./)" ]'

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kilo-io/iptables_parser
 
-go 1.16
+go 1.18

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,7 @@ package iptables_parser
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"reflect"
@@ -84,6 +85,39 @@ func TestStringPair_Spec(t *testing.T) {
 		if res := tc.p.Spec(tc.f); !reflect.DeepEqual(res, tc.r) {
 			t.Errorf("test %d:\n\texp=%q\n\tgot=%q\n", i, tc.r, res)
 		}
+	}
+}
+
+func TestDNSOrIP_Set(t *testing.T) {
+	for i, tc := range []struct {
+		in  string
+		out []string
+	}{
+		{
+			in:  "10.10.0.0/16",
+			out: []string{"-s", "10.10.0.0/16"},
+		},
+		{
+			in:  "10.10.0.1",
+			out: []string{"-s", "10.10.0.1/32"},
+		},
+		{
+			in:  "10::/64",
+			out: []string{"-s", "10::/64"},
+		},
+		{
+			in:  "10::10",
+			out: []string{"-s", "10::10/128"},
+		},
+	} {
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			dnsOrIpPair := &DNSOrIPPair{}
+
+			dnsOrIpPair.Value.Set(tc.in)
+			if res := dnsOrIpPair.Spec("-s"); !reflect.DeepEqual(res, tc.out) {
+				t.Errorf("test %d:\n\texp=%q\n\tgot=%q\n", i, tc.out, res)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Before we would always add a `/32` to ip addresses without a `/`. This would be wrong for ipv6 addresses. They have 128 network masks.