### PR TITLE
Use fuzzing to fix some bugs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -115,7 +115,7 @@ func NewFromString(s string) (Line, error) {
 // Note: Don't use this functions to compare rules because the order of flags can be
 // different and different flags can have equal meanings.
 func (r Rule) String() (s string) {
-	s = fmt.Sprintf("-A %s %s", r.Chain, strings.Join(enquoteIfWS(r.Spec()), " "))
+	s = fmt.Sprintf("-A %s %s", enquoteIfWS(r.Chain)[0], strings.Join(enquoteIfWS(r.Spec()...), " "))
 	if r.Counter != nil {
 		s = fmt.Sprintf("%s %s", r.Counter.String(), s)
 	}
@@ -432,6 +432,9 @@ var (
 )
 
 func (p *Parser) parseDefault(lit string) (Line, error) {
+	if len(strings.TrimSpace(lit)) == 0 {
+		return nil, fmt.Errorf("nothing to parse in %q", lit)
+	}
 	var r Policy
 	r.Chain = string(regDefault.ReplaceAll([]byte(lit), []byte("$1")))
 	a := regDefault.ReplaceAll([]byte(lit), []byte("$2"))
@@ -720,7 +723,7 @@ func (p *Parser) unscan(n int) {
 
 var hasWS *regexp.Regexp = regexp.MustCompile(`\s`)
 
-func enquoteIfWS(s []string) []string {
+func enquoteIfWS(s ...string) []string {
 	ret := make([]string, len(s))
 	for i, e := range s {
 		if hasWS.MatchString(e) {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,6 +1,7 @@
 package iptables_parser
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -31,13 +32,15 @@ func TestScanner_Scan(t *testing.T) {
 		{s: "# 192.168.178.2/24", tok: COMMENTLINE, lit: " 192.168.178.2/24"},
 		{s: "I_test_rule-something", tok: IDENT, lit: "I_test_rule-something"},
 	} {
-		s := newScanner(strings.NewReader(tc.s))
-		tok, lit := s.scan()
-		if tc.tok != tok {
-			t.Errorf("%d. %q token mismatch: exp=%q got=%q <%q>", i, tc.s, tc.tok, tok, lit)
-		} else if tc.lit != lit {
-			t.Errorf("%d. %q literal mismatch: exp=%q got=%q", i, tc.s, tc.lit, lit)
-		}
+		t.Run(fmt.Sprintf("%d. %q", i, tc.s), func(t *testing.T) {
+			s := newScanner(strings.NewReader(tc.s))
+			tok, lit := s.scan()
+			if tc.tok != tok {
+				t.Errorf("%q token mismatch: exp=%q got=%q <%q>", tc.s, tc.tok, tok, lit)
+			} else if tc.lit != lit {
+				t.Errorf("%q literal mismatch: exp=%q got=%q", tc.s, tc.lit, lit)
+			}
+		})
 	}
 }
 

--- a/testdata/fuzz/FuzzParser_Parse/55cbba0554d1434e
+++ b/testdata/fuzz/FuzzParser_Parse/55cbba0554d1434e
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("-A\" 0")

--- a/testdata/fuzz/FuzzParser_Parse/82c2975c430ac608
+++ b/testdata/fuzz/FuzzParser_Parse/82c2975c430ac608
@@ -1,0 +1,2 @@
+go test fuzz v1
+string(":")


### PR DESCRIPTION
This commit adds a fuzz test and fixes some of the bugs found with
fuzzing the input of the `(*Parser).Parse()`.
